### PR TITLE
issue resolved

### DIFF
--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -296,7 +296,6 @@ class EAnnouncementsView(FlaskView):
 
         return render_template("e-announcements/future.html")
 
-    @cache.memoize(timeout=3601)
     @route("/ea_future", methods=['POST'])
     def ea_future(self):
         if 'E-Announcement Approver' not in session['groups'].split(';') and 'Administrators' not in session['groups'].split(';'):
@@ -309,29 +308,7 @@ class EAnnouncementsView(FlaskView):
         forms = self.base.traverse_xml(app.config['E_ANNOUNCEMENTS_XML_URL'], 'system-block', True)
         forms.sort(key=lambda item: ['created_on'], reverse=True)
 
-        def get_title_and_message(form):
-            title = find(form, 'title', False)
-            message = find(form, 'message', False)
-            ea_id = find(form, 'id', False)
-            created = find(form, 'created-on', False)
-            ea_display.append({
-                'title': title,
-                'message': message,
-                'id': ea_id
-            })
-            # ea_display.append(message)
-
-        for form in forms:
-            first_ea_date = find(form, 'first_date', False)
-
-            if first_ea_date == str(date_id):
-                get_title_and_message(form)
-
-            # second date is not always present, the second date if statements are necessary
-            second_ea_date = find(form, 'second_date', False)
-            if second_ea_date != '':
-                if second_ea_date == str(date_id):
-                    get_title_and_message(form)
+        self.base.get_upcoming(forms, date_id, ea_display)
 
         return render_template("e-announcements/future-ajax.html", **locals())
 

--- a/tinker/e_announcements/e_announcements_controller.py
+++ b/tinker/e_announcements/e_announcements_controller.py
@@ -1,12 +1,13 @@
 # Global
 from datetime import datetime
+from bu_cascade.asset_tools import find
 
 # Packages
 from bu_cascade.asset_tools import update
 from flask import session
 
 # Local
-from tinker import app
+from tinker import app, cache
 from tinker.tinker_controller import TinkerController
 
 
@@ -229,3 +230,29 @@ class EAnnouncementsController(TinkerController):
                 to_return.append(annz)
 
         return to_return, forms_header
+
+    def get_title_and_message(self, form, ea_display):
+        title = find(form, 'title', False)
+        message = find(form, 'message', False)
+        ea_id = find(form, 'id', False)
+        created = find(form, 'created-on', False)
+        ea_display.append({
+            'title': title,
+            'message': message,
+            'id': ea_id
+        })
+
+    @cache.memoize(timeout=599)
+    def get_upcoming(self, forms, date_id, ea_display):
+        for form in forms:
+            first_ea_date = find(form, 'first_date', False)
+
+            if first_ea_date == str(date_id):
+                self.get_title_and_message(form, ea_display)
+
+            # second date is not always present, the second date if statements are necessary
+            second_ea_date = find(form, 'second_date', False)
+            if second_ea_date != '':
+                if second_ea_date == str(date_id):
+                    self.get_title_and_message(form, ea_display)
+        return ea_display

--- a/tinker/e_announcements/e_announcements_controller.py
+++ b/tinker/e_announcements/e_announcements_controller.py
@@ -242,7 +242,7 @@ class EAnnouncementsController(TinkerController):
             'id': ea_id
         })
 
-    @cache.memoize(timeout=599)
+    @cache.memoize(timeout=600)
     def get_upcoming(self, forms, date_id, ea_display):
         for form in forms:
             first_ea_date = find(form, 'first_date', False)


### PR DESCRIPTION
Issue was caused due to cacheing results. The method containing the search was being cached, which caused the results to be cached. This made the same results show up for every date after the first request. I moved the search to the tinker controller and reduced the cache time from an hour to 10 minutes. 