### PR TITLE
remove html comments

### DIFF
--- a/tinker/static/ckeditor/config.js
+++ b/tinker/static/ckeditor/config.js
@@ -23,17 +23,3 @@ CKEDITOR.editorConfig = function( config ) {
 		CKEDITOR.config.entities = false;
 		CKEDITOR.config.extraPlugins = 'bu_removecomments';
 };
-
-// i am not sure this works, but it is difficult to actually test. In theory, this should prevent html comments
-// from being sent to cascade. I am taking a gamble in hoping this fixes the junk that gets sent - caleb
-CKEDITOR.replaceAll( 'ckeditor', {
-    on: {
-        pluginsLoaded: function( evt ) {
-            evt.editor.dataProcessor.dataFilter.addRules( {
-                comment: function() {
-                    return false;
-                }
-            } );
-        }
-    }
-} );

--- a/tinker/static/ckeditor/config.js
+++ b/tinker/static/ckeditor/config.js
@@ -21,6 +21,7 @@ CKEDITOR.editorConfig = function( config ) {
 		];
 		CKEDITOR.config.removeButtons = 'Underline,Subscript,Superscript,Undo,Redo,Cut,Copy,Paste,PasteText,PasteFromWord,Scayt,Strike,RemoveFormat,Blockquote,Anchor,Image,Table,HorizontalRule,SpecialChar,Maximize,Source,Styles';
 		CKEDITOR.config.entities = false;
+		CKEDITOR.config.extraPlugins = 'bu_removecomments';
 };
 
 // i am not sure this works, but it is difficult to actually test. In theory, this should prevent html comments

--- a/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
+++ b/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
@@ -2,7 +2,6 @@ CKEDITOR.plugins.add('bu_removecomments', {
     init: function (editor) {
         var text = editor.getData();
         text = text.replace(/<!--(.*?)-->/gs, "");
-        console.log(text);
         editor.setData(text);
     }
 });

--- a/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
+++ b/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
@@ -1,0 +1,8 @@
+CKEDITOR.plugins.add('bu_removecomments', {
+    init: function (editor) {
+        var text = editor.getData();
+        text = text.replace(/<!--(.*?)-->/gs, "");
+        console.log(text);
+        editor.setData(text);
+    }
+});

--- a/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
+++ b/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
@@ -6,7 +6,7 @@ CKEDITOR.plugins.add('bu_removecomments', {
         editor.setData(text);
 
         // This checks content on paste, needed for editing or creating new faculty bios
-        editor.on('paste', function(e){
+        editor.on('paste', function(){
             setTimeout(function(){ // Need a timeout so the paste is registered before we change any data.
                 var text = editor.getData();
                 text = text.replace(/<!--(.*?)-->/gs, "");

--- a/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
+++ b/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
@@ -1,7 +1,17 @@
 CKEDITOR.plugins.add('bu_removecomments', {
     init: function (editor) {
+        // This runs when the editor is initialized. This is needed for editing existing faculty bios
         var text = editor.getData();
         text = text.replace(/<!--(.*?)-->/gs, "");
         editor.setData(text);
+
+        // This checks content on paste, needed for editing or creating new faculty bios
+        editor.on('paste', function(e){
+            setTimeout(function(){ // Need a timeout so the paste is registered before we change any data.
+                var text = editor.getData();
+                text = text.replace(/<!--(.*?)-->/gs, "");
+                editor.setData(text);
+            }, 100);
+        });
     }
 });


### PR DESCRIPTION
Created a custom CKEditor plugin to remove html comments from the WYSIWYG text areas. Fixes #339.