### PR TITLE
Updated regex

### DIFF
--- a/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
+++ b/tinker/static/ckeditor/plugins/bu_removecomments/plugin.js
@@ -1,15 +1,18 @@
+// The regex used below checks for html comments in the form <!--asdf--> and also takes into account newlines and
+// the html encoding of the "<" and ">" characters. The question mark is needed so that if there are multiple html
+// comments with data in between we don't lose that data.
 CKEDITOR.plugins.add('bu_removecomments', {
     init: function (editor) {
         // This runs when the editor is initialized. This is needed for editing existing faculty bios
         var text = editor.getData();
-        text = text.replace(/<!--(.*?)-->/gs, "");
+        text = text.replace(/(<|&lt;)!--((.|\n)*?)--(>|&gt;)/g, "");
         editor.setData(text);
 
         // This checks content on paste, needed for editing or creating new faculty bios
         editor.on('paste', function(){
             setTimeout(function(){ // Need a timeout so the paste is registered before we change any data.
                 var text = editor.getData();
-                text = text.replace(/<!--(.*?)-->/gs, "");
+                text = text.replace(/(<|&lt;)!--((.|\n)*?)--(>|&gt;)/g, "");
                 editor.setData(text);
             }, 100);
         });


### PR DESCRIPTION
## Description

Firefox doesn't recognize the "s" tag so we needed to check for a newline explicitly. Also I didn't realize this last time but sometimes the "<" and ">" characters are encoded so we need to take their html encodings into account too.

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Tested locally on multiple browsers.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)