### PR TITLE
Added the fix to compensate for the odd timezone issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ redis
 paramiko
 python-ldap
 Flask-Mail
+pytz

--- a/tinker/news/__init__.py
+++ b/tinker/news/__init__.py
@@ -73,7 +73,7 @@ class NewsView(FlaskView):
                                                              list_ids,
                                                              segment_ids, template_id, template_content)
 
-                    now = datetime.datetime.now()
+                    now = self.base_campaign.date_without_dst()
                     now_plus_10 = now + datetime.timedelta(minutes=10)
 
                     confirmation_email_sent_to = ', '.join(app.config['ADMINS'])

--- a/tinker/news/campaign_controller.py
+++ b/tinker/news/campaign_controller.py
@@ -100,9 +100,9 @@ class NewsController(TinkerController):
         tz = pytz.timezone('US/Central').localize(now).strftime('%z')
 
         # this is super hacky. The issue is Campaign Monitor updates our date with respect to timezone. Since we can
-        # only pass a string, we need to do the timezone update ourselves. if '5' is in tz, then we need to subtract
+        # only pass a string, we need to do the timezone update ourselves. if '-0500' is in tz, then we need to subtract
         # an hour to compensate.
-        if '5' in tz:
+        if '-0500' in tz:
             return now + datetime.timedelta(hours=-1)
         else:
             return now

--- a/tinker/news/campaign_controller.py
+++ b/tinker/news/campaign_controller.py
@@ -1,6 +1,7 @@
 # Global
 import datetime
 import HTMLParser
+import pytz
 
 # Packages
 from BeautifulSoup import BeautifulStoneSoup
@@ -93,3 +94,15 @@ class NewsController(TinkerController):
         asset, md, sd = page.get_asset()
         update(sd, 'send-email', 'No')
         page.edit_asset(asset)
+
+    def date_without_dst(self):
+        now = datetime.datetime.now()
+        tz = pytz.timezone('US/Central').localize(now).strftime('%z')
+
+        # this is super hacky. The issue is Campaign Monitor updates our date with respect to timezone. Since we can
+        # only pass a string, we need to do the timezone update ourselves. if '5' is in tz, then we need to subtract
+        # an hour to compensate.
+        if '5' in tz:
+            return now + datetime.timedelta(hours=-1)
+        else:
+            return now


### PR DESCRIPTION
## Description

For the news campaigns that we send, they are always an hour in the future (plus the 10 minutes we add). I found a way to check for the current timezone offset, then if its an hour ahead, i subtract an hour.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix
- Venv update needed

## How Has This Been Tested?

- locally, i am able to update the hour and create the campaign on delivery.bethel.edu.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
