### PR TITLE
Update email content to use CDN and added comment

### DIFF
--- a/tinker/templates/news/article.html
+++ b/tinker/templates/news/article.html
@@ -7,7 +7,8 @@
                     <p class="article-meta" style="margin-top:10px">{{ date }}</p>
                 </div>
                 <div style="Margin-left: 20px;Margin-right: 20px;">
-                    <img src="https://www.bethel.edu/{{ image_path }}" width="100%">
+                    {# 1000 pixels will cover the largest size that will appear in an email, since we restrict the width of the email content. #}
+                    <img src="https://cdn1.bethel.edu/resize/unsafe/1000x0/smart/https://https://www.bethel.edu/{{ image_path }}" width="100%">
                     {{ content|safe }}
                     <div style="text-align:center;padding-top:30px"><!--[if mso]>
                       <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://www.bethel.edu/{{ path }}" style="height:40px;v-text-anchor:middle;width:200px;" arcsize="8%" strokecolor="#1e3650" fillcolor="#0069aa">


### PR DESCRIPTION
## Description

News emails were sending out with upside down images, rarely. That occurs due to some applications using EXIF image metadata, and others don't. This is using cdn, which handles it as expected.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- I tested this locally, but ran the code to create a campaign in carlyle (delivery.bethel.edu).
- I then sent a test email from that campaign, which fixed the issue - should be a complete test.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
