### PR TITLE
Changed elifs to ifs to allow for multiple Faculty Bio groups

### DIFF
--- a/tinker/faculty_bios/faculty_bio_controller.py
+++ b/tinker/faculty_bios/faculty_bio_controller.py
@@ -79,14 +79,14 @@ class FacultyBioController(TinkerController):
             # Because the user running this operation is in a group that's authorized to edit this bio
             iterate_bio = True
         else:
+            schools_to_check = []
             if 'Tinker Faculty Bios - CAS' in groups:
-                schools_to_check = ['College of Arts and Sciences']
-            elif 'Tinker Faculty Bios - CAPS and GS' in groups:
-                schools_to_check = ['College of Adult and Professional Studies', 'Graduate School']
-            elif 'Tinker Faculty Bios - SEM' in groups:
-                schools_to_check = ['Bethel Seminary']
-            else:
-                schools_to_check = []
+                schools_to_check.append('College of Arts and Sciences')
+            if 'Tinker Faculty Bios - CAPS and GS' in groups:
+                schools_to_check.append('College of Adult and Professional Studies')
+                schools_to_check.append('Graduate School')
+            if 'Tinker Faculty Bios - SEM' in groups:
+                schools_to_check.append('Bethel Seminary')
 
             if len(schools_to_check) > 0:
                 school_values = []


### PR DESCRIPTION
## Description

This is a small change to the logic of Faculty Bio permissions. It allows users to have access to multiple schools. 

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

I ran this locally and on XP, works fine both places.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
