### PR TITLE
Add in the bethel alert pieces

### DIFF
--- a/tinker/__init__.py
+++ b/tinker/__init__.py
@@ -123,6 +123,7 @@ def get_url_from_path(path, **kwargs):
 
 
 # New importing of routes and blueprints
+from tinker.admin.bethel_alert import BethelAlertView
 from tinker.admin.program_search import ProgramSearchView
 from tinker.admin.publish import PublishView
 from tinker.admin.redirects import RedirectsView
@@ -136,6 +137,7 @@ from tinker.office_hours import OfficeHoursView
 from tinker.views import View
 from tinker.unit_test_interface import UnitTestInterfaceView
 
+BethelAlertView.register(app)
 ProgramSearchView.register(app)
 PublishView.register(app)
 RedirectsView.register(app)

--- a/tinker/admin/bethel_alert/__init__.py
+++ b/tinker/admin/bethel_alert/__init__.py
@@ -1,0 +1,41 @@
+# Global
+import json
+import requests
+
+from flask import render_template, session
+from flask_classy import FlaskView, route
+
+# Local
+from tinker import app
+from tinker.tinker_controller import admin_permissions
+
+
+class BethelAlertView(FlaskView):
+    route_base = '/admin/bethel-alert'
+
+    # This method is called before any request to check user's credentials
+    def before_request(self, name, **kwargs):
+        admin_permissions(self)
+
+    def index(self):
+        return render_template('admin/bethel_alert/home.html', **locals())
+
+    @route("/clear-cache", methods=['post'])
+    def clear_cache(self):
+        # TODO: still need to clear MyBethel's feed as well!
+        try:
+            status_code = requests.get('https://staging.bethel.edu/code/news/php/news_article_feed_clear_cache', auth=(app.config['CASCADE_LOGIN']['username'], app.config['CASCADE_LOGIN']['password'])).status_code
+            if status_code == 200:
+                return json.dumps({
+                    'type': 'success',
+                    'message': 'Success! The caches have been cleared. You should be able to see your Public Bethel Alert on the applicable feeds.'
+                })
+            else:
+                raise Exception
+        except:
+            return json.dumps({
+                'type': 'danger',
+                'message': 'ERROR: Please try again. If it still does not work, contact Web Development.'
+            })
+
+

--- a/tinker/admin/bethel_alert/__init__.py
+++ b/tinker/admin/bethel_alert/__init__.py
@@ -25,7 +25,7 @@ class BethelAlertView(FlaskView):
         # TODO: still need to clear MyBethel's feed as well!
         try:
             # this route clears the cache
-            status_code = requests.get('https://staging.bethel.edu/code/news/php/news_article_feed_clear_cache', auth=(app.config['CASCADE_LOGIN']['username'], app.config['CASCADE_LOGIN']['password'])).status_code
+            status_code = requests.get('https://www.bethel.edu/code/news/php/news_article_feed_clear_cache', auth=(app.config['CASCADE_LOGIN']['username'], app.config['CASCADE_LOGIN']['password'])).status_code
             if status_code == 200:
                 return json.dumps({
                     'type': 'success',

--- a/tinker/admin/bethel_alert/__init__.py
+++ b/tinker/admin/bethel_alert/__init__.py
@@ -24,6 +24,7 @@ class BethelAlertView(FlaskView):
     def clear_cache(self):
         # TODO: still need to clear MyBethel's feed as well!
         try:
+            # this route clears the cache
             status_code = requests.get('https://staging.bethel.edu/code/news/php/news_article_feed_clear_cache', auth=(app.config['CASCADE_LOGIN']['username'], app.config['CASCADE_LOGIN']['password'])).status_code
             if status_code == 200:
                 return json.dumps({

--- a/tinker/templates/admin/bethel_alert/home.html
+++ b/tinker/templates/admin/bethel_alert/home.html
@@ -1,0 +1,51 @@
+{% extends "tinker_base.html" %}
+
+{% set title = 'Bethel Alert' %}
+
+{% block title %}Program Search Tags{% endblock %}
+
+{% block styles %}
+{% endblock %}
+
+{% block page_title %}Bethel University Tinker{% endblock %}
+
+{% block main_content %}
+    <div class="content">
+        <div class="container-fluid">
+            <div class="col-md-12">
+                <p>Bethel Alerts are cached in news feeds in various places: www.bethel.edu, www.bethel.edu/news, www.bethel.edu/news/archive, and the mybethel news feeds.
+                    <br>
+                    <br>
+                    By clicking this button, you will ONLY clear the caches that the Bethel Alerts will appear on. Push this button AFTER a Bethel alert has been published AND the xml has finished publishing.
+                </p>
+                <a href="#" id="clear-cache" class="btn btn-primary">Clear News Caches</a>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block scripts %}
+    <script type="text/javascript">
+        $("#clear-cache").click(function () {
+            $.ajax({
+                type: "POST",
+                url: "{{ url_for('BethelAlertView:clear_cache')}}",
+                contentType: 'application/json;charset=UTF-8',
+                success: function (data) {
+                    if(data) {
+                        data = JSON.parse(data);
+                        $.notify({
+                            message: data.message
+                        }, {
+                            type: data.type,
+                            placement: {
+                                align: 'center'
+                            },
+
+                        });
+                    }
+                }
+            });
+        });
+    </script>
+{% endblock %}

--- a/tinker/templates/admin/bethel_alert/home.html
+++ b/tinker/templates/admin/bethel_alert/home.html
@@ -2,7 +2,7 @@
 
 {% set title = 'Bethel Alert' %}
 
-{% block title %}Program Search Tags{% endblock %}
+{% block title %}Bethel Alert - Clear Cache{% endblock %}
 
 {% block styles %}
 {% endblock %}

--- a/tinker/templates/creative_tim_sidebar.html
+++ b/tinker/templates/creative_tim_sidebar.html
@@ -58,6 +58,12 @@
                     <ul class="dropdown-menu">
                         {% if 'Administrators' in session['groups'] %}
                             <li>
+                                <a href="{{ url_for('BethelAlertView:index') }}">
+                                    <i class="fa fa-file" aria-hidden="true"></i>
+                                    <p class="admin-list-item">Bethel Alert</p>
+                                </a>
+                            </li>
+                            <li>
                                 <a href="{{ url_for('PublishView:index') }}">
                                     <i class="fa fa-file" aria-hidden="true"></i>
                                     <p class="admin-list-item">Publisher</p>

--- a/tinker/templates/creative_tim_sidebar.html
+++ b/tinker/templates/creative_tim_sidebar.html
@@ -59,7 +59,7 @@
                         {% if 'Administrators' in session['groups'] %}
                             <li>
                                 <a href="{{ url_for('BethelAlertView:index') }}">
-                                    <i class="fa fa-file" aria-hidden="true"></i>
+                                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                     <p class="admin-list-item">Bethel Alert</p>
                                 </a>
                             </li>


### PR DESCRIPTION
## Description

Add in the interface to clear the cache of various news feeds. This will allow Bethel Alerts to be cleared

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature

## How Has This Been Tested?

- I tested locally.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
