### PR TITLE
Add in notes to redirects

### DIFF
--- a/tinker/admin/redirects/__init__.py
+++ b/tinker/admin/redirects/__init__.py
@@ -64,6 +64,7 @@ class RedirectsView(FlaskView):
         to_url = form['new-redirect-to']
         short_url = form.get('new-redirect-short-url') == 'true'
         expiration_date = form.get('expiration-date')
+        notes = form.get('new-notes')
 
         if expiration_date:
             expiration_date = datetime.strptime(expiration_date, "%a %b %d %Y")
@@ -74,7 +75,7 @@ class RedirectsView(FlaskView):
             if not from_path.startswith("/"):
                 from_path = "/%s" % from_path
             try:
-                new_redirect = self.base.add_row_to_db(from_path, to_url, short_url, expiration_date)
+                new_redirect = self.base.add_row_to_db(from_path, to_url, short_url, expiration_date, notes)
                 # Update the file after every submit?
                 self.base.create_redirect_text_file()
                 return json.dumps({
@@ -108,6 +109,7 @@ class RedirectsView(FlaskView):
         to_url = form['edit-redirect-to']
         short_url = form.get('edit-redirect-short-url') == 'true'
         expiration_date = form.get('edit-expiration-date')
+        notes = form.get('edit-notes')
         username = session["username"]
         last_edited = datetime.now()
 
@@ -140,7 +142,8 @@ class RedirectsView(FlaskView):
                     'to_url': to_url,
                     'short_url': short_url,
                     'expiration_date': expiration_date,
-                    'last_edited': last_edited
+                    'last_edited': last_edited,
+                    'notes': notes
                 }
                 edit_redirect = BethelRedirect.query.filter(BethelRedirect.id == id)
                 edit_redirect.update(edit_dict)

--- a/tinker/admin/redirects/models.py
+++ b/tinker/admin/redirects/models.py
@@ -2,6 +2,7 @@ from tinker import db
 from datetime import datetime
 from flask import session
 
+
 class BethelRedirect(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     from_path = db.Column(db.String(256), unique=True, default='no_path_provided')
@@ -11,12 +12,15 @@ class BethelRedirect(db.Model):
     timestamp = db.Column(db.Date, default=datetime.now())
     username = db.Column(db.String(20), default='n/a')
     last_edited = db.Column(db.Date, default=datetime.now())
+    notes = db.Column(db.String(512), default="n/a")
 
-    def __init__(self, from_path, to_url, short_url=None, expiration_date=None, username=None):
+    def __init__(self, from_path, to_url, short_url=None, expiration_date=None, username=None, last_edited=None, notes=None):
         self.from_path = from_path
         self.to_url = to_url
         self.short_url = short_url
         self.expiration_date = expiration_date
+        self.last_edited = last_edited
+        self.notes = notes
         if username:
             self.username = username
         else:

--- a/tinker/admin/redirects/models.py
+++ b/tinker/admin/redirects/models.py
@@ -12,7 +12,7 @@ class BethelRedirect(db.Model):
     timestamp = db.Column(db.Date, default=datetime.now())
     username = db.Column(db.String(20), default='n/a')
     last_edited = db.Column(db.Date, default=datetime.now())
-    notes = db.Column(db.String(512), default="n/a")
+    notes = db.Column(db.String(256))
 
     def __init__(self, from_path, to_url, short_url=None, expiration_date=None, username=None, last_edited=None, notes=None):
         self.from_path = from_path

--- a/tinker/admin/redirects/redirects_controller.py
+++ b/tinker/admin/redirects/redirects_controller.py
@@ -41,7 +41,7 @@ class RedirectsController(TinkerController):
 
         return 'done'
 
-    def add_row_to_db(self, from_path, to_url, short_url, expiration_date, username=None):
+    def add_row_to_db(self, from_path, to_url, short_url, expiration_date, notes, username=None):
         if from_path == '/':
             return False
 
@@ -49,7 +49,7 @@ class RedirectsController(TinkerController):
             username = session["username"]
 
         new_redirect = BethelRedirect(from_path=from_path, to_url=to_url, short_url=short_url,
-                                      expiration_date=expiration_date, username=username)
+                                      expiration_date=expiration_date, username=username, notes=notes)
         self.db.session.add(new_redirect)
         self.db.session.commit()
         return new_redirect

--- a/tinker/static/assets/css/tinker.css
+++ b/tinker/static/assets/css/tinker.css
@@ -583,13 +583,14 @@ label {
 }
 
 .redirect-table th:nth-child(1),
-.redirect-table th:nth-child(4){
-    width: 10%;
+.redirect-table th:nth-child(5){
+    width: 12.25%;
 }
 
 .redirect-table th:nth-child(2),
-.redirect-table th:nth-child(3){
-    width: 40%;
+.redirect-table th:nth-child(3),
+.redirect-table th:nth-child(4){
+    width: 25%;
 }
 
 .redirect-btn{

--- a/tinker/templates/admin/redirects/ajax.html
+++ b/tinker/templates/admin/redirects/ajax.html
@@ -23,7 +23,7 @@
             data-id="{{ redirect.id }}" data-username="{{ redirect.username }}"
             data-timestamp="{{ data_timestamp }}" data-exp-date="{{ redirect.expiration_date }}"
              data-from-path="{{ redirect.from_path }}" data-to-url="{{ redirect.to_url }}"
-             data-short-url="{{ redirect.short_url }}" data-last-edited="{{ data_last_edited }}">
+             data-short-url="{{ redirect.short_url }}" data-last-edited="{{ data_last_edited }}" data-notes="{{ redirect.notes }}">
                 <i class="fa fa-info-circle"></i>
             </div>
         </td>
@@ -39,6 +39,9 @@
 
         <!-- To URL -->
         <td class="to_url">{{ redirect.to_url }}</td>
+
+        <!-- Notes -->
+        <td class="notes">{% if redirect.notes %}{{ redirect.notes }}{% endif %}</td>
 
         <!-- Delete Column -->
         <td>

--- a/tinker/templates/admin/redirects/home.html
+++ b/tinker/templates/admin/redirects/home.html
@@ -44,6 +44,14 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="row less-left-margin">
+                                <div class="col-sm-12">
+                                    <div class="form-group">
+                                        Notes:
+                                        <textarea id="new-notes" class="form-control no-margin-bottom"></textarea>
+                                    </div>
+                                </div>
+                            </div>
                             <label class="checkbox" for="new-redirect-short-url">
                                 <span class="icons">
                                     <span class="first-icon fa fa-square-o"></span>
@@ -120,6 +128,7 @@
                     $("#modal-from-path-display").text($(this).data("from-path"));
                     $("#modal-to-url-display").text($(this).data("to-url"));
                     $("#modal-last-edited-display").text($(this).data("last-edited"));
+                    $("#modal-edit-notes-display").text($(this).data("notes"));
                     // Shows info
                     $(".display").show();
                     // Checkbox for short url
@@ -146,6 +155,7 @@
                     $("#modal-from-path-edit").val($(this).data('from-path'));
                     $("#modal-to-url-edit").val($(this).data('to-url'));
                     $("#modal-last-edited-edit").val($(this).data("last-edited"));
+                    $("#modal-edit-notes").val($(this).data("notes"));
                     // Hiding edit fields
                     $(".edit").hide()
                 });
@@ -239,7 +249,8 @@
                         'new-redirect-from': $('#new-redirect-from').val(),
                         'new-redirect-to': $('#new-redirect-to').val(),
                         'new-redirect-short-url': $('#new-redirect-short-url').parent().hasClass('checked'),
-                        'expiration-date': $('#expiration-date').val()
+                        'expiration-date': $('#expiration-date').val(),
+                        'new-notes': $('#new-notes').val()
                     };
 
                     var url = "{{ url_for('RedirectsView:new_redirect_submit') }}";
@@ -287,7 +298,8 @@
                         'edit-redirect-from': $('#modal-from-path-edit').val(),
                         'edit-redirect-to': $('#modal-to-url-edit').val(),
                         'edit-redirect-short-url': $('#edit-redirect-short-url').parent().hasClass('checked'),
-                        'edit-expiration-date': $('#modal-exp-date-edit').val()
+                        'edit-expiration-date': $('#modal-exp-date-edit').val(),
+                        'edit-notes': $('#modal-edit-notes').val()
                     };
                     var url = "{{ url_for('RedirectsView:edit_redirect_submit') }}";
                     $.post(url, edits, function (edits) {
@@ -313,6 +325,7 @@
                 $('#new-redirect-to').val('');
                 $('#new-redirect-from').val('');
                 $('#expiration-date').val('');
+                $('#new-notes').val('');
                 $('#new-redirect-short-url').attr('checked', false);
                 $('#new-redirect-short-url').parent().removeClass('checked');
             }
@@ -422,6 +435,13 @@
                             <td>
                                 <span id="modal-last-edited-display" class="display">No timestamp was loaded</span>
                                 <input type="text" id="modal-last-edited-edit" class="uneditable edit" readonly/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Notes:</th>
+                            <td>
+                                <span id="modal-edit-notes-display" class="display">No notes were loaded</span>
+                                <input type="text" id="modal-edit-notes" class="edit"/>
                             </td>
                         </tr>
                     </table>

--- a/tinker/templates/admin/redirects/home.html
+++ b/tinker/templates/admin/redirects/home.html
@@ -441,6 +441,7 @@
                         <tr>
                             <th>Notes:</th>
                             <td>
+                                <span id="modal-edit-notes-display" class="display">No notes were loaded</span>
                                 <input type="text" id="modal-edit-notes" class="edit"/>
                             </td>
                         </tr>

--- a/tinker/templates/admin/redirects/home.html
+++ b/tinker/templates/admin/redirects/home.html
@@ -441,7 +441,6 @@
                         <tr>
                             <th>Notes:</th>
                             <td>
-                                <span id="modal-edit-notes-display" class="display">No notes were loaded</span>
                                 <input type="text" id="modal-edit-notes" class="edit"/>
                             </td>
                         </tr>

--- a/tinker/templates/admin/redirects/home.html
+++ b/tinker/templates/admin/redirects/home.html
@@ -74,6 +74,7 @@
                         <th>Info</th>
                         <th>From Path</th>
                         <th>To URL</th>
+                        <th>Notes</th>
                         <th>Delete</th>
                     </tr>
                     </thead>

--- a/tinker/templates/events/form.html
+++ b/tinker/templates/events/form.html
@@ -45,24 +45,24 @@
 
             if (reverse_logic == true) {
                 if (document.getElementById(noend).checked) {
-                    document.getElementById(endlabel).style.display = 'block'
-                    document.getElementById(end).style.display = 'block'
+                    document.getElementById(endlabel).style.display = 'block';
+                    document.getElementById(end).style.display = 'block';
                 }
                 else {
                     document.getElementById(end).value = '';
-                    document.getElementById(endlabel).style.display = 'none'
-                    document.getElementById(end).style.display = 'none'
+                    document.getElementById(endlabel).style.display = 'none';
+                    document.getElementById(end).style.display = 'none';
                 }
             }
             else {
                 if (document.getElementById(noend).checked) {
                     document.getElementById(end).value = '';
-                    document.getElementById(endlabel).style.display = 'none'
-                    document.getElementById(end).style.display = 'none'
+                    document.getElementById(endlabel).style.display = 'none';
+                    document.getElementById(end).style.display = 'none';
                 }
                 else {
-                    document.getElementById(endlabel).style.display = 'block'
-                    document.getElementById(end).style.display = 'block'
+                    document.getElementById(endlabel).style.display = 'block';
+                    document.getElementById(end).style.display = 'block';
                 }
             }
         }


### PR DESCRIPTION
## Description

Added in a text field to help us keep track of why redirects exist and added the value of the text field to the redirects table in the DB.

Fixes #379 

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

- DB needs updating (adding in notes column)

## How Has This Been Tested?

Added a new redirect with notes. Notes were displayed when looking for that redirect. I was able to edit the notes successfully.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
