### PR TITLE
Add in default expiration date of 3 years 

### DIFF
--- a/tinker/admin/redirects/__init__.py
+++ b/tinker/admin/redirects/__init__.py
@@ -32,6 +32,7 @@ class RedirectsView(FlaskView):
 
     # Redirects homepage
     def index(self):
+        default_expiration_date = datetime.now() + timedelta(days=365*3)
         redirects = self.base.get_all_rows()
         return render_template('admin/redirects/home.html', **locals())
 

--- a/tinker/admin/redirects/models.py
+++ b/tinker/admin/redirects/models.py
@@ -7,7 +7,7 @@ class BethelRedirect(db.Model):
     from_path = db.Column(db.String(256), unique=True, default='no_path_provided')
     to_url = db.Column(db.String(256))
     short_url = db.Column(db.Boolean)
-    expiration_date = db.Column(db.Date, default=(datetime.now() + timedelta(days=365*3)))
+    expiration_date = db.Column(db.Date)
     timestamp = db.Column(db.Date, default=datetime.now())
     username = db.Column(db.String(20), default='n/a')
     last_edited = db.Column(db.Date, default=datetime.now())

--- a/tinker/admin/redirects/models.py
+++ b/tinker/admin/redirects/models.py
@@ -1,5 +1,5 @@
 from tinker import db
-from datetime import datetime
+from datetime import datetime, timedelta
 from flask import session
 
 class BethelRedirect(db.Model):
@@ -7,7 +7,7 @@ class BethelRedirect(db.Model):
     from_path = db.Column(db.String(256), unique=True, default='no_path_provided')
     to_url = db.Column(db.String(256))
     short_url = db.Column(db.Boolean)
-    expiration_date = db.Column(db.Date)
+    expiration_date = db.Column(db.Date, default=(datetime.now() + timedelta(days=365*3)))
     timestamp = db.Column(db.Date, default=datetime.now())
     username = db.Column(db.String(20), default='n/a')
     last_edited = db.Column(db.Date, default=datetime.now())

--- a/tinker/templates/admin/redirects/home.html
+++ b/tinker/templates/admin/redirects/home.html
@@ -40,10 +40,18 @@
                                 <div class="col-sm-4">
                                     <div class="form-group">
                                         Expiration Date:
-                                        <input type="text" id="expiration-date" class="form-control no-margin-bottom"/>
+                                        <input type="text" id="expiration-date" value="{{ default_expiration_date }}" class="form-control no-margin-bottom"/>
                                     </div>
                                 </div>
                             </div>
+                            <label id="no-redirect-expiration-label" class="checkbox" for="no-redirect-expiration-date">
+                                <span class="icons">
+                                    <span class="first-icon fa fa-square-o"></span>
+                                    <span class="second-icon fa fa-check-square-o"></span>
+                                </span>
+                                <input type="checkbox" name="no-redirect-expiration-date" id="no-redirect-expiration-date">
+                                No expiration date
+                            </label>
                             <label class="checkbox" for="new-redirect-short-url">
                                 <span class="icons">
                                     <span class="first-icon fa fa-square-o"></span>
@@ -99,6 +107,19 @@
                         });
                     }
                 });
+            });
+
+            $("#no-redirect-expiration-label").click(function() {
+
+                if (!$("#no-redirect-expiration-date").is(":checked")) {
+                    $("#expiration-date").val("");
+                } else {
+                    let date = new Date("{{ default_expiration_date }}");
+                    let dateString = date.toString();
+                    console.log(dateString);
+                    date = dateString.split(" ")[0] + " " + dateString.split(" ")[1] + " " + dateString.split(" ")[2] + " " + dateString.split(" ")[3];
+                    $("#expiration-date").val(date);
+                }
             });
 
             function updateTable(data) {

--- a/tinker/templates/admin/redirects/home.html
+++ b/tinker/templates/admin/redirects/home.html
@@ -113,7 +113,9 @@
 
                 if (!$("#no-redirect-expiration-date").is(":checked")) {
                     $("#expiration-date").val("");
+                    $("#expiration-date").prop("disabled", true);
                 } else {
+                    $("#expiration-date").prop("disabled", false);
                     let date = new Date("{{ default_expiration_date }}");
                     let dateString = date.toString();
                     console.log(dateString);


### PR DESCRIPTION
## Description

Added a default expiration date of 3 years along with a way to have no definite expiration date by selecting a checkbox.

Fixes #386

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

Locally I tested that the default date of roughly 3 years (1095 days) was working and also that the indefinite expiration date was working.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
