### PR TITLE
Issue 399 Fix - No e-annz updates after 1pm

### DIFF
--- a/testing_suite/unit_tests/e_announcements_tests/campaign_controller_tests/campaign_controller_base.py
+++ b/testing_suite/unit_tests/e_announcements_tests/campaign_controller_tests/campaign_controller_base.py
@@ -1,8 +1,10 @@
 from testing_suite.unit_tests import UnitTestCase
 from tinker.e_announcements import CampaignController
+from tinker.e_announcements.e_announcements_controller import EAnnouncementsController
 
 
 class CampaignControllerBaseTestCase(UnitTestCase):
     def __init__(self, methodName):
         super(CampaignControllerBaseTestCase, self).__init__(methodName)
         self.controller = CampaignController()
+        self.base = EAnnouncementsController()

--- a/testing_suite/unit_tests/e_announcements_tests/campaign_controller_tests/test_is_bethel_holiday.py
+++ b/testing_suite/unit_tests/e_announcements_tests/campaign_controller_tests/test_is_bethel_holiday.py
@@ -18,50 +18,50 @@ class IsBethelHolidayTestCase(CampaignControllerBaseTestCase):
     def test_is_bethel_holiday(self):
         # Assert new years is a holiday
         test_date = datetime(2017, 1, 1)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertTrue(response)
 
         # Assert new years' observed
         test_date = datetime(2017, 1, 2)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertTrue(response)
 
         # Assert MLK Day
         test_date = datetime(2017, 1, 16)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertTrue(response)
 
         # Assert Memorial Day
         test_date = datetime(2017, 5, 29)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertTrue(response)
 
         # Assert July 4th
         test_date = datetime(2017, 7, 4)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertTrue(response)
 
         # Assert Labor Day
         test_date = datetime(2017, 9, 4)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertTrue(response)
 
         # Assert black Friday
         test_date = datetime(2017, 11, 24)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertTrue(response)
 
         # Assert Christmas eve observed
         test_date = datetime(2016, 12, 23)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertTrue(response)
 
         # Assert any given day in 12/24 - 12/31
         for date in [datetime(2017, 12, number) for number in range(24, 32)]:
-            response = self.controller.is_bethel_holiday(date)
+            response = self.base.is_bethel_holiday(date)
             self.assertTrue(response)
 
         # Assert not any other day
         test_date = datetime(2016, 12, 21)
-        response = self.controller.is_bethel_holiday(test_date)
+        response = self.base.is_bethel_holiday(test_date)
         self.assertFalse(response)

--- a/testing_suite/unit_tests/e_announcements_tests/campaign_controller_tests/test_is_date_friday_before_easter.py
+++ b/testing_suite/unit_tests/e_announcements_tests/campaign_controller_tests/test_is_date_friday_before_easter.py
@@ -17,9 +17,9 @@ class IsDateFridayBeforeEasterTestCase(CampaignControllerBaseTestCase):
 
     def test_is_date_friday_before_easter(self):
         friday_before_easter = datetime(2017, 4, 14)
-        response = self.controller.is_date_friday_before_easter(friday_before_easter)
+        response = self.base.is_date_friday_before_easter(friday_before_easter)
         self.assertTrue(response)
 
         friday_after_easter = datetime(2017, 4, 21)
-        response = self.controller.is_date_friday_before_easter(friday_after_easter)
+        response = self.base.is_date_friday_before_easter(friday_after_easter)
         self.assertFalse(response)

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -344,21 +344,25 @@ class EAnnouncementsView(FlaskView):
                 first_date = datetime.datetime.strptime(result['first_date'].replace(',', ''), '%A %B %d %Y')
                 day_before = get_day_before(first_date)
 
-                while self.base.is_bethel_holiday(day_before):
-                    if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year:
+                while self.base.is_bethel_holiday(day_before): # while the day before is a holiday
+                    if today.month == day_before.month and today.day == day_before.day \
+                            and today.year == day_before.year: # if today is the same day as a holiday make un-editable
                         search_results[count]['editable'] = False
                         break
-                    day_before = get_day_before(day_before)
+                    day_before = get_day_before(day_before) # go one day backwards
 
+                # if today is weekend or today is the day before a holiday(s) starts and after 1pm make un-editable
                 if today.weekday() == 5 or today.weekday() == 6 or \
                         (today.month == day_before.month and today.day == day_before.day
                          and today.year == day_before.year and today.hour >= 13):
                     search_results[count]['editable'] = False
+                # else if posting day is monday and today is friday and after 1pm or tomorrow is posting date and time
+                # is after 1pm make un-editable
                 elif (first_date.weekday() == 0 and (today.weekday() == 4 and today.hour >= 13)) or \
                         (today.month == tomorrow.month and today.day == tomorrow.day and today.year == tomorrow.year
                          and today.hour >= 13):
                     search_results[count]['editable'] = False
-                else:
+                else: # else make editable
                     search_results[count]['editable'] = True
 
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -355,18 +355,27 @@ class EAnnouncementsView(FlaskView):
 
                 if day_before.weekday() == 6:
                     if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year:
+                        # Check if today is the same day as that day, if so make it uneditable
                         search_results[count]['editable'] = False
                     else:
+                        # If the today isn't the same day, go a day before
                         day_before = get_day_before(day_before)
+                # If a holiday is Monday or Sunday, but Saturday isn't a holiday
                 if day_before.weekday() == 5:
                     if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year:
+                        # Check if today is the same day as that day, if so make it uneditable
                         search_results[count]['editable'] = False
                     else:
+                        # If the today isn't the same day, go a day before
                         day_before = get_day_before(day_before)
+                # If Monday, Sunday, or Saturday are holidays but Friday isn't a holiday and it is after 1pm, then
+                # make it uneditable
                 if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year \
                         and today.hour >= 13:
                     search_results[count]['editable'] = False
 
+                # If the post date isn't near a holiday then just check if annz post date is for tomorrow, if so and it
+                # is after 1pm, make uneditable
                 if (first_date.weekday() == 0 and (today.weekday() == 6 or today.weekday() == 5 or today.weekday() == 4
                                                    and today.hour >= 13)) or (first_date.month == tomorrow.month and
                                                                               first_date.day == tomorrow.day and

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -361,11 +361,12 @@ class EAnnouncementsView(FlaskView):
                     search_results[count]['editable'] = False
                 # else if posting day is monday and today is friday and after 1pm or tomorrow is posting date and time
                 # is after 1pm make un-editable
-                elif (first_date.weekday() == 0 and (today.weekday() == 6 or today.weekday() == 5 or today.weekday() == 4 and today.hour >= 13)) or \
-                        (today.month == tomorrow.month and today.day == tomorrow.day and today.year == tomorrow.year
-                         and today.hour >= 13):
+                elif (first_date.weekday() == 0 and (today.weekday() == 6 or today.weekday() == 5 or today.weekday() ==
+                                                     4 and today.hour >= 13)) or (today.month == tomorrow.month and
+                                                                                  (today + datetime.timedelta(days=1)).day
+                                                                                  == tomorrow.day and today.year == tomorrow.year
+                                                                                  and today.hour >= 13):
                     search_results[count]['editable'] = False
                 elif editable:  # else make editable
                     search_results[count]['editable'] = True
-
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -332,9 +332,9 @@ class EAnnouncementsView(FlaskView):
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
 
         def get_day_before(dto):
-            day_before = dto - datetime.timedelta(days=1)
+            yester = dto - datetime.timedelta(days=1)
 
-            return day_before
+            return yester
 
         count = 0
         for result in search_results:
@@ -342,17 +342,17 @@ class EAnnouncementsView(FlaskView):
                 search_results[count]['editable'] = False
             else:
                 first_date = datetime.datetime.strptime(result['first_date'].replace(',', ''), '%A %B %d %Y')
-                yester = get_day_before(first_date)
+                day_before = get_day_before(first_date)
 
-                while self.base.is_bethel_holiday(yester):
-                    if today.month == yester.month and today.day == yester.day and today.year == yester.year:
+                while self.base.is_bethel_holiday(day_before):
+                    if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year:
                         search_results[count]['editable'] = False
                         break
                     yester = get_day_before(first_date)
 
                 if today.weekday() == 5 or today.weekday() == 6 or \
-                        (today.month == yester.month and today.day == yester.day
-                         and today.year == yester.year and today.hour >= 13):
+                        (today.month == day_before.month and today.day == day_before.day
+                         and today.year == day_before.year and today.hour >= 13):
                     search_results[count]['editable'] = False
                 elif (first_date.weekday() == 0 and (today.weekday() == 4 and today.hour >= 13)) or \
                         (today.month == tomorrow.month and today.day == tomorrow.day and today.year == tomorrow.year

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -338,7 +338,7 @@ class EAnnouncementsView(FlaskView):
 
         count = 0
         for result in search_results:
-            if not result['first_date_past']:
+            if result['first_date_past']:
                 search_results[count]['editable'] = False
             else:
                 first_date = datetime.datetime.strptime(result['first_date'].replace(',', ''), '%A %B %d %Y')

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -348,7 +348,7 @@ class EAnnouncementsView(FlaskView):
                     if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year:
                         search_results[count]['editable'] = False
                         break
-                    yester = get_day_before(first_date)
+                    day_before = get_day_before(day_before)
 
                 if today.weekday() == 5 or today.weekday() == 6 or \
                         (today.month == day_before.month and today.day == day_before.day

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -353,7 +353,6 @@ class EAnnouncementsView(FlaskView):
                         break
                     day_before = get_day_before(day_before)  # go one day backwards
 
-                # if today is weekend or today is the day before a holiday(s) starts and after 1pm make un-editable
                 if ((day_before.weekday() == 5 or day_before.weekday() == 6) and (today.month == day_before.month
                     and today.day == day_before.day and today.year == day_before.year)) or \
                         (today.month == day_before.month and today.day == day_before.day

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -353,15 +353,20 @@ class EAnnouncementsView(FlaskView):
                         break
                     day_before = get_day_before(day_before)  # go one day backwards
 
-                if ((day_before.weekday() == 5 or day_before.weekday() == 6) and (today.month == day_before.month
-                                                                                    and today.day == day_before.day
-                                                                                    and today.year == day_before.year)) \
-                        or (today.month == day_before.month and today.day == day_before.day and today.year ==
-                            day_before.year and today.hour >= 13):  # if today is weekend or today is the day before a holiday(s) starts and after 1pm make un-editable
+                if day_before.weekday() == 6:
+                    if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year:
+                        search_results[count]['editable'] = False
+                    else:
+                        day_before = get_day_before(day_before)
+                if day_before.weekday() == 5:
+                    if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year:
+                        search_results[count]['editable'] = False
+                    else:
+                        day_before = get_day_before(day_before)
+                if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year \
+                        and today.hour >= 13:
                     search_results[count]['editable'] = False
 
-                # if the posting day is monday and today is friday and after 1pm or tomorrow is posting date and time
-                # is after 1pm make un-editable
                 if (first_date.weekday() == 0 and (today.weekday() == 6 or today.weekday() == 5 or today.weekday() == 4
                                                    and today.hour >= 13)) or (first_date.month == tomorrow.month and
                                                                               first_date.day == tomorrow.day and

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -354,9 +354,10 @@ class EAnnouncementsView(FlaskView):
                     day_before = get_day_before(day_before)  # go one day backwards
 
                 if ((day_before.weekday() == 5 or day_before.weekday() == 6) and (today.month == day_before.month
-                    and today.day == day_before.day and today.year == day_before.year)) or \
-                        (today.month == day_before.month and today.day == day_before.day
-                         and today.year == day_before.year and today.hour >= 13):
+                                                                                    and today.day == day_before.day
+                                                                                    and today.year == day_before.year)) \
+                        or (today.month == day_before.month and today.day == day_before.day and today.year ==
+                            day_before.year and today.hour >= 13):  # if today is weekend or today is the day before a holiday(s) starts and after 1pm make un-editable
                     search_results[count]['editable'] = False
 
                 # if the posting day is monday and today is friday and after 1pm or tomorrow is posting date and time

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -361,11 +361,11 @@ class EAnnouncementsView(FlaskView):
                     search_results[count]['editable'] = False
                 # else if posting day is monday and today is friday and after 1pm or tomorrow is posting date and time
                 # is after 1pm make un-editable
-                elif (first_date.weekday() == 0 and (today.weekday() == 6 or today.weekday() == 5 or today.weekday() ==
-                                                     4 and today.hour >= 13)) or (today.month == tomorrow.month and
-                                                                                  (today + datetime.timedelta(days=1)).day
-                                                                                  == tomorrow.day and today.year == tomorrow.year
-                                                                                  and today.hour >= 13):
+                if (first_date.weekday() == 0 and (today.weekday() == 6 or today.weekday() == 5 or today.weekday() == 4
+                                                   and today.hour >= 13)) or (first_date.month == tomorrow.month and
+                                                                              first_date.day == tomorrow.day and
+                                                                              first_date.year == tomorrow.year
+                                                                              and today.hour >= 13):
                     search_results[count]['editable'] = False
             count += 1
 

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -359,7 +359,8 @@ class EAnnouncementsView(FlaskView):
                         (today.month == day_before.month and today.day == day_before.day
                          and today.year == day_before.year and today.hour >= 13):
                     search_results[count]['editable'] = False
-                # else if posting day is monday and today is friday and after 1pm or tomorrow is posting date and time
+
+                # if the posting day is monday and today is friday and after 1pm or tomorrow is posting date and time
                 # is after 1pm make un-editable
                 if (first_date.weekday() == 0 and (today.weekday() == 6 or today.weekday() == 5 or today.weekday() == 4
                                                    and today.hour >= 13)) or (first_date.month == tomorrow.month and

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -367,4 +367,6 @@ class EAnnouncementsView(FlaskView):
                                                                                   == tomorrow.day and today.year == tomorrow.year
                                                                                   and today.hour >= 13):
                     search_results[count]['editable'] = False
+            count += 1
+
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -341,15 +341,15 @@ class EAnnouncementsView(FlaskView):
             if result['first_date_past']:
                 search_results[count]['editable'] = False
             else:
+                search_results[count]['editable'] = True
+
                 first_date = datetime.datetime.strptime(result['first_date'].replace(',', ''), '%A %B %d %Y')
                 day_before = get_day_before(first_date)
 
-                editable = True
                 while self.base.is_bethel_holiday(day_before):  # while the day before is a holiday
                     if today.month == day_before.month and today.day == day_before.day \
                             and today.year == day_before.year:  # if today is the same day as a holiday make un-editable
                         search_results[count]['editable'] = False
-                        editable = False
                         break
                     day_before = get_day_before(day_before)  # go one day backwards
 
@@ -367,6 +367,4 @@ class EAnnouncementsView(FlaskView):
                                                                                   == tomorrow.day and today.year == tomorrow.year
                                                                                   and today.hour >= 13):
                     search_results[count]['editable'] = False
-                elif editable:  # else make editable
-                    search_results[count]['editable'] = True
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -324,6 +324,17 @@ class EAnnouncementsView(FlaskView):
             date = datetime.datetime.strptime(date, "%a %b %d %Y")
         except:
             date = 0
+
+        time_tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
+
+        tomorrow = {
+            "month": time_tomorrow.strftime("%B"),
+            "day": time_tomorrow.strftime("%d"),
+            "year": time_tomorrow.strftime("%Y"),
+        }
+
+        hour_today = time_tomorrow.strftime("%H")
+
         search_results, forms_header = self.base.get_search_results(selection, title, date)
         search_results.sort(key=lambda item: datetime.datetime.strptime(item['first_date'], '%A %B %d, %Y'), reverse=True)
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -353,7 +353,9 @@ class EAnnouncementsView(FlaskView):
                         break
                     day_before = get_day_before(day_before)  # go one day backwards
 
+                # If a holiday is Monday but Sunday isn't a holiday
                 if day_before.weekday() == 6:
+
                     if today.month == day_before.month and today.day == day_before.day and today.year == day_before.year:
                         # Check if today is the same day as that day, if so make it uneditable
                         search_results[count]['editable'] = False

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -344,12 +344,12 @@ class EAnnouncementsView(FlaskView):
                 first_date = datetime.datetime.strptime(result['first_date'].replace(',', ''), '%A %B %d %Y')
                 day_before = get_day_before(first_date)
 
-                while self.base.is_bethel_holiday(day_before): # while the day before is a holiday
+                while self.base.is_bethel_holiday(day_before):  # while the day before is a holiday
                     if today.month == day_before.month and today.day == day_before.day \
-                            and today.year == day_before.year: # if today is the same day as a holiday make un-editable
+                            and today.year == day_before.year:  # if today is the same day as a holiday make un-editable
                         search_results[count]['editable'] = False
                         break
-                    day_before = get_day_before(day_before) # go one day backwards
+                    day_before = get_day_before(day_before)  # go one day backwards
 
                 # if today is weekend or today is the day before a holiday(s) starts and after 1pm make un-editable
                 if today.weekday() == 5 or today.weekday() == 6 or \

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -328,14 +328,8 @@ class EAnnouncementsView(FlaskView):
         search_results, forms_header = self.base.get_search_results(selection, title, date)
         search_results.sort(key=lambda item: datetime.datetime.strptime(item['first_date'], '%A %B %d, %Y'), reverse=True)
 
-        tomorrow = {
-            "month": time_tomorrow.strftime("%B"),
-            "day": time_tomorrow.strftime("%d"),
-            "year": time_tomorrow.strftime("%Y"),
-        }
         today = datetime.datetime.today()
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
 
-        hour_today = time_tomorrow.strftime("%H")
 
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -344,25 +344,28 @@ class EAnnouncementsView(FlaskView):
                 first_date = datetime.datetime.strptime(result['first_date'].replace(',', ''), '%A %B %d %Y')
                 day_before = get_day_before(first_date)
 
+                editable = True
                 while self.base.is_bethel_holiday(day_before):  # while the day before is a holiday
                     if today.month == day_before.month and today.day == day_before.day \
                             and today.year == day_before.year:  # if today is the same day as a holiday make un-editable
                         search_results[count]['editable'] = False
+                        editable = False
                         break
                     day_before = get_day_before(day_before)  # go one day backwards
 
                 # if today is weekend or today is the day before a holiday(s) starts and after 1pm make un-editable
-                if today.weekday() == 5 or today.weekday() == 6 or \
+                if ((day_before.weekday() == 5 or day_before.weekday() == 6) and (today.month == day_before.month
+                    and today.day == day_before.day and today.year == day_before.year)) or \
                         (today.month == day_before.month and today.day == day_before.day
                          and today.year == day_before.year and today.hour >= 13):
                     search_results[count]['editable'] = False
                 # else if posting day is monday and today is friday and after 1pm or tomorrow is posting date and time
                 # is after 1pm make un-editable
-                elif (first_date.weekday() == 0 and (today.weekday() == 4 and today.hour >= 13)) or \
+                elif (first_date.weekday() == 0 and (today.weekday() == 6 or today.weekday() == 5 or today.weekday() == 4 and today.hour >= 13)) or \
                         (today.month == tomorrow.month and today.day == tomorrow.day and today.year == tomorrow.year
                          and today.hour >= 13):
                     search_results[count]['editable'] = False
-                else: # else make editable
+                elif editable:  # else make editable
                     search_results[count]['editable'] = True
 
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -331,5 +331,34 @@ class EAnnouncementsView(FlaskView):
         today = datetime.datetime.today()
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
 
+        def get_day_before(dto):
+            day_before = dto - datetime.timedelta(days=1)
+
+            return day_before
+
+        count = 0
+        for result in search_results:
+            if not result['first_date_past']:
+                search_results[count]['editable'] = False
+            else:
+                first_date = datetime.datetime.strptime(result['first_date'].replace(',', ''), '%A %B %d %Y')
+                yester = get_day_before(first_date)
+
+                while self.base.is_bethel_holiday(yester):
+                    if today.month == yester.month and today.day == yester.day and today.year == yester.year:
+                        search_results[count]['editable'] = False
+                        break
+                    yester = get_day_before(first_date)
+
+                if today.weekday() == 5 or today.weekday() == 6 or \
+                        (today.month == yester.month and today.day == yester.day
+                         and today.year == yester.year and today.hour >= 13):
+                    search_results[count]['editable'] = False
+                elif (first_date.weekday() == 0 and (today.weekday() == 4 and today.hour >= 13)) or \
+                        (today.month == tomorrow.month and today.day == tomorrow.day and today.year == tomorrow.year
+                         and today.hour >= 13):
+                    search_results[count]['editable'] = False
+                else:
+                    search_results[count]['editable'] = True
 
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -325,16 +325,17 @@ class EAnnouncementsView(FlaskView):
         except:
             date = 0
 
-        time_tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
+        search_results, forms_header = self.base.get_search_results(selection, title, date)
+        search_results.sort(key=lambda item: datetime.datetime.strptime(item['first_date'], '%A %B %d, %Y'), reverse=True)
 
         tomorrow = {
             "month": time_tomorrow.strftime("%B"),
             "day": time_tomorrow.strftime("%d"),
             "year": time_tomorrow.strftime("%Y"),
         }
+        today = datetime.datetime.today()
+        tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
 
         hour_today = time_tomorrow.strftime("%H")
 
-        search_results, forms_header = self.base.get_search_results(selection, title, date)
-        search_results.sort(key=lambda item: datetime.datetime.strptime(item['first_date'], '%A %B %d, %Y'), reverse=True)
         return render_template('e-announcements/results.html', **locals())

--- a/tinker/e_announcements/campaign_controller.py
+++ b/tinker/e_announcements/campaign_controller.py
@@ -1,15 +1,20 @@
 # Global
 import datetime
-import math
 
 # Packages
 from flask import render_template
 
 # Local
 from tinker.tinker_controller import TinkerController
+from tinker.e_announcements.e_announcements_controller import EAnnouncementsController
 
 
 class CampaignController(TinkerController):
+
+    def __init__(self):
+        super(CampaignController, self).__init__()
+        self.base = EAnnouncementsController()
+
     # creates the campaign monitor 'if' structure along with the html
     def create_single_announcement(self, announcement):
         return_value = ''
@@ -49,59 +54,10 @@ class CampaignController(TinkerController):
         if date.weekday() in [1, 3, 5, 6]:
             return False
 
-        if self.is_bethel_holiday(date):
+        if self.base.is_bethel_holiday(date):
             return False
 
         return True
-
-    def is_bethel_holiday(self, date):
-        # New years
-        if date.month == 1 and date.day == 1:
-            return True
-        # New Years(observed) -- If new years day is on the weekend, we get the monday off (2nd or 3rd)
-        elif date.month == 1 and date.weekday() == 0 and (date.day == 2 or date.day == 3):
-            return True
-        # MLK Day - 3rd monday in jan
-        elif date.month == 1 and date.weekday() == 0 and math.ceil(date.day/7.0) == 3:
-            return True
-        # Easter (is the date the friday before easter)
-        elif self.is_date_friday_before_easter(date):
-            return True
-        # memorial day - last monday in may (may, date is after 24th and its a monday)
-        elif date.month == 5 and date.day > 24 and date.weekday() == 0:
-            return True
-        # july 4
-        elif date.month == 7 and date.day == 4:
-            return True
-        # Labor Day - first monday in sept
-        elif date.month == 9 and date.weekday() == 0 and math.ceil(date.day/7.0) == 1:
-            return True
-        # Black Friday -- the friday after the fourth thursday in nov
-        elif date.month == 11 and math.ceil((date.day-1)/7.0) == 4 and date.weekday() == 4:
-            return True
-        # Christmas Eve(observed) - christmas eve is on the weekend, we get the friday off (22nd or 23rd).
-        elif date.month == 12 and date.weekday() == 4 and (date.day == 22 or date.day == 23):
-            return True
-        # christmas days
-        elif date.month == 12 and date.day >= 24:
-            return True
-
-        return False
-
-    def is_date_friday_before_easter(self, date):
-        year = date.year
-
-        # code from http://code.activestate.com/recipes/576517-calculate-easter-western-given-a-year/
-        a = year % 19
-        b = year // 100
-        c = year % 100
-        d = (19 * a + b - b // 4 - ((b - (b + 8) // 25 + 1) // 3) + 15) % 30
-        e = (32 + 2 * (b % 4) + 2 * (c // 4) - d - (c % 4)) % 7
-        f = d + e - 7 * ((a + 11 * d + 22 * e) // 451) + 114
-        month = f // 31
-        day = f % 31 + 1
-
-        return date.month == month and date.day == (day - 2)
 
     def get_layout_for_no_announcements(self, roles):
         if_block = ''

--- a/tinker/e_announcements/e_announcements_controller.py
+++ b/tinker/e_announcements/e_announcements_controller.py
@@ -1,6 +1,7 @@
 # Global
 from datetime import datetime
 from bu_cascade.asset_tools import find
+import math
 
 # Packages
 from bu_cascade.asset_tools import update
@@ -256,3 +257,52 @@ class EAnnouncementsController(TinkerController):
                 if second_ea_date == str(date_id):
                     self.get_title_and_message(form, ea_display)
         return ea_display
+
+    def is_bethel_holiday(self, date):
+        # New years
+        if date.month == 1 and date.day == 1:
+            return True
+        # New Years(observed) -- If new years day is on the weekend, we get the monday off (2nd or 3rd)
+        elif date.month == 1 and date.weekday() == 0 and (date.day == 2 or date.day == 3):
+            return True
+        # MLK Day - 3rd monday in jan
+        elif date.month == 1 and date.weekday() == 0 and math.ceil(date.day/7.0) == 3:
+            return True
+        # Easter (is the date the friday before easter)
+        elif self.is_date_friday_before_easter(date):
+            return True
+        # memorial day - last monday in may (may, date is after 24th and its a monday)
+        elif date.month == 5 and date.day > 24 and date.weekday() == 0:
+            return True
+        # july 4
+        elif date.month == 7 and date.day == 4:
+            return True
+        # Labor Day - first monday in sept
+        elif date.month == 9 and date.weekday() == 0 and math.ceil(date.day/7.0) == 1:
+            return True
+        # Black Friday -- the friday after the fourth thursday in nov
+        elif date.month == 11 and math.ceil((date.day-1)/7.0) == 4 and date.weekday() == 4:
+            return True
+        # Christmas Eve(observed) - christmas eve is on the weekend, we get the friday off (22nd or 23rd).
+        elif date.month == 12 and date.weekday() == 4 and (date.day == 22 or date.day == 23):
+            return True
+        # christmas days
+        elif date.month == 12 and date.day >= 24:
+            return True
+
+        return False
+
+    def is_date_friday_before_easter(self, date):
+        year = date.year
+
+        # code from http://code.activestate.com/recipes/576517-calculate-easter-western-given-a-year/
+        a = year % 19
+        b = year // 100
+        c = year % 100
+        d = (19 * a + b - b // 4 - ((b - (b + 8) // 25 + 1) // 3) + 15) % 30
+        e = (32 + 2 * (b % 4) + 2 * (c // 4) - d - (c % 4)) % 7
+        f = d + e - 7 * ((a + 11 * d + 22 * e) // 451) + 114
+        month = f // 31
+        day = f % 31 + 1
+
+        return date.month == month and date.day == (day - 2)

--- a/tinker/static/assets/css/tinker.css
+++ b/tinker/static/assets/css/tinker.css
@@ -841,6 +841,11 @@ p.text-field-info {
     top: 85px;
 }
 
+#uneditable {
+    display:block;
+    margin-bottom: 1em;
+}
+
 #updateTags {
     margin-bottom: 10px;
 }

--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -20,13 +20,16 @@
                         <li>This announcement is pending approval.</li>
                     {% else %}
                         {% if not form.first_date_past and not form.second_date_past %}
-                            <li>
-                                {% if (first_date[1] == tomorrow.month and first_date[2] == tomorrow.day and first_date[3] == tomorrow.year) and hour_today > 13 %}
+                                {% if (first_date[1] == tomorrow.month and first_date[2] != tomorrow.day and first_date[3] == tomorrow.year) and hour_today > 13 %}
+                                    <li id="uneditable">
+                                        You can't edit after 1pm the day before an e-announcement is sent
+                                    </li>
                                 {% else %}
-                                    <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"#}
-                                       class="btn btn-primary">Edit</a>
+                                    <li>
+                                        <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"#}
+                                           class="btn btn-primary">Edit</a>
+                                    </li>
                                 {% endif %}
-                            </li>
                         {% else %}
                             <li>
                                 <a href="{{ url_for('EAnnouncementsView:view', e_announcement_id=form.id) }}"

--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -21,11 +21,9 @@
                     {% else %}
                         {% if not form.first_date_past and not form.second_date_past %}
                             <li>
-                                {% if (first_date[1] != tomorrow.month) or (first_date[1] == tomorrow.month and first_date[2] != tomorrow.day) %}
-                                    <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"
-                                       class="btn btn-primary">Edit</a>
-                                {% elif hour_today < 13 %}
-                                    <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"
+                                {% if (first_date[1] == tomorrow.month and first_date[2] == tomorrow.day and first_date[3] == tomorrow.year) and hour_today > 13 %}
+                                {% else %}
+                                    <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"#}
                                        class="btn btn-primary">Edit</a>
                                 {% endif %}
                             </li>

--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -15,7 +15,6 @@
             </p>
             <div class="large-6 columns small-3">
                 <ul class="btn-group-horizontal">
-{#                {% set first_date = form.first_date.split(" ") -%}#}
                     {% if form.workflow_status %}
                         <li>This announcement is pending approval.</li>
                     {% else %}

--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -15,21 +15,11 @@
             </p>
             <div class="large-6 columns small-3">
                 <ul class="btn-group-horizontal">
-                {% set first_date = form.first_date.split(" ") -%}
+{#                {% set first_date = form.first_date.split(" ") -%}#}
                     {% if form.workflow_status %}
                         <li>This announcement is pending approval.</li>
                     {% else %}
                         {% if not form.first_date_past and not form.second_date_past %}
-                                {% if (first_date[1] == tomorrow.month and first_date[2] != tomorrow.day and first_date[3] == tomorrow.year) and hour_today > 13 %}
-                                    <li id="uneditable">
-                                        You can't edit after 1pm the day before an e-announcement is sent
-                                    </li>
-                                {% else %}
-                                    <li>
-                                        <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"
-                                           class="btn btn-primary">Edit</a>
-                                    </li>
-                                {% endif %}
                         {% else %}
                             <li>
                                 <a href="{{ url_for('EAnnouncementsView:view', e_announcement_id=form.id) }}"

--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -26,7 +26,7 @@
                                     </li>
                                 {% else %}
                                     <li>
-                                        <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"#}
+                                        <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"
                                            class="btn btn-primary">Edit</a>
                                     </li>
                                 {% endif %}

--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -15,13 +15,22 @@
             </p>
             <div class="large-6 columns small-3">
                 <ul class="btn-group-horizontal">
+                {% set first_date = form.first_date.split(" ") -%}
+
+                <p>{{ first_date }} {{ hour_today }} {{ tomorrow }}</p>
                     {% if form.workflow_status %}
                         <li>This announcement is pending approval.</li>
                     {% else %}
                         {% if not form.first_date_past and not form.second_date_past %}
                             <li>
-                                <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"
-                                   class="btn btn-primary">Edit</a></li>
+                                {% if (first_date[1] != tomorrow.month) or (first_date[1] == tomorrow.month and first_date[2] != tomorrow.day) %}
+                                    <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"
+                                       class="btn btn-primary">Edit</a>
+                                {% elif hour_today < 13 %}
+                                    <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"
+                                       class="btn btn-primary">Edit</a>
+                                {% endif %}
+                            </li>
                         {% else %}
                             <li>
                                 <a href="{{ url_for('EAnnouncementsView:view', e_announcement_id=form.id) }}"

--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -16,8 +16,6 @@
             <div class="large-6 columns small-3">
                 <ul class="btn-group-horizontal">
                 {% set first_date = form.first_date.split(" ") -%}
-
-                <p>{{ first_date }} {{ hour_today }} {{ tomorrow }}</p>
                     {% if form.workflow_status %}
                         <li>This announcement is pending approval.</li>
                     {% else %}

--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -20,6 +20,16 @@
                         <li>This announcement is pending approval.</li>
                     {% else %}
                         {% if not form.first_date_past and not form.second_date_past %}
+                            {% if form.editable %}
+                                <li>
+                                    <a href="{{ url_for('EAnnouncementsView:edit', e_announcement_id=form.id) }}"
+                                       class="btn btn-primary">Edit</a>
+                                </li>
+                            {% else %}
+                                <li id="uneditable">
+                                    You can't edit an e-announcement after 1pm the business day before it is to be sent
+                                </li>
+                            {% endif %}
                         {% else %}
                             <li>
                                 <a href="{{ url_for('EAnnouncementsView:view', e_announcement_id=form.id) }}"


### PR DESCRIPTION
## Description

Added in logic to restrict users from editing e-announcements after 1pm of the business day before they are being sent out.

Fixes #399 

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

I did some basic testing as to test that the edit button appears for future e-announcements and doesn't appear for past e-announcements but I wasn't able to test that this works successfully given that e-announcements are sent out on Monday, Wednesday, and Friday and I work those days (since I would have to work Tuesday/Thursday and be here around 1pm to test this).

I might move xp to this branch to check whether or not the 1pm cutoff works by looking at an e-announcement being sent the next day and verifying that the "edit" button disappears after 1pm.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
