### PR TITLE
update comment to only be displayed if running locally

### DIFF
--- a/tinker/templates/admin/user-roles/home.html
+++ b/tinker/templates/admin/user-roles/home.html
@@ -1,6 +1,10 @@
 {% extends "tinker_base.html" %}
 
-{% set title = 'User Roles (Doesnt work Locally)' %}
+{% if 'xp' not in config['ENVIRON'] and 'prod' not in config['ENVIRON'] %}
+    {% set title = 'User Roles (Doesn\'t work Locally)' %}
+{% else %}
+    {% set title = 'User Roles' %}
+{% endif %}
 
 {% block page_title %}Bethel University Tinker{% endblock %}
 

--- a/tinker/templates/creative_tim_sidebar.html
+++ b/tinker/templates/creative_tim_sidebar.html
@@ -81,8 +81,10 @@
                                 <a href="{{ url_for('UserRolesView:index') }}">
                                     <i class="fa fa-user-secret" aria-hidden="true"></i>
                                     <p class="admin-list-item">User Test Roles</p>
-                                     doesnt work locally
-                                     local session cookie not being stored
+                                    {% if 'xp' not in config['ENVIRON'] and 'prod' not in config['ENVIRON'] %}
+                                        doesn't work locally;
+                                        local session cookie not being stored
+                                    {% endif %}
                                 </a>
                             </li>
                         {% endif %}


### PR DESCRIPTION
## Description

Added code to make it so comment that only applies to running locally only shows when running locally.

Fixes #405 

## Size and Type of change

- Small Change - 1 person needs to review this

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

Tested locally by changing the `ENVIRON` variable in config to 'xp' and 'prod' and verifying that the text wouldn't show up, but it would show up when `ENVIRON` was set to anything else.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)