### PR TITLE
Add in code to force e-announcements to the top

### DIFF
--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -186,7 +186,6 @@ class EAnnouncementsView(FlaskView):
             else:
                 date = datetime.datetime.strptime(date, "%m-%d-%Y")
 
-            # send a
             if 'create_and_send_campaign' in request.url_rule.rule and app.config['ENVIRON'] == 'prod':
                 self.base.log_sentry("E-Announcement create_and_send_campaign was called on production", date)
 
@@ -212,9 +211,14 @@ class EAnnouncementsView(FlaskView):
                     continue
 
                 # add announcement
-                announcement_text = self.base_campaign.create_single_announcement(announcement)
+                force_top, announcement_text = self.base_campaign.create_single_announcement(announcement)
                 if announcement_text != '':
-                    submitted_announcements.append({
+                    # announcements with "force_top" appear at the beginning of the list. If multiple, it depends on creation order
+                    if force_top == 'Yes':
+                        index_to_insert = 0
+                    else:
+                        index_to_insert = len(submitted_announcements)
+                    submitted_announcements.insert(index_to_insert,{
                         "Layout":
                             "announcements",
                         "Multilines": [

--- a/tinker/e_announcements/campaign_controller.py
+++ b/tinker/e_announcements/campaign_controller.py
@@ -33,7 +33,7 @@ class CampaignController(TinkerController):
 
             return_value += '[endif]'
 
-        return return_value
+        return announcement['force-top'], return_value
 
     # builds the html
     def e_announcement_html(self, announcement):

--- a/tinker/e_announcements/e_announcements_controller.py
+++ b/tinker/e_announcements/e_announcements_controller.py
@@ -94,6 +94,7 @@ class EAnnouncementsController(TinkerController):
             'id': child.attrib['id'] or "",
             'title': child.find('title').text or None,
             'created-on': child.find('created-on').text or None,
+            'force-top': child.find('system-data-structure/force-top').text or "",
             'first_date': first_date,
             'second_date': second_date,
             'roles': roles,


### PR DESCRIPTION
## Description

Marketing (Christine and Tim) asked me to force an e-announcement to the top of the email. This is the 2nd time they asked me, so I went ahead and built out some functionality for it. E-Announcements have an option that only the E-Annz approver has access to put an e-annz to the top.

Another note: I made it so the Data Definition value for the E-annz moving to top ONLY appears for the E-Announcement Approver group.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature
- Contact Christine and TIm

## How Has This Been Tested?

- I tested by making my updates, attempting to create e-annz. The specific e-annz was in the middle of the list
- I tested again with making the e-annz have the DD option. It appeared at the top.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)