### PR TITLE
Event length issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ flask_profiler.sql
 programs.csv
 faculty-info.csv
 config_old
+
+venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/venv/*
 config.py
 *.pyc
 migrations/

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,3 @@ flask_profiler.sql
 programs.csv
 faculty-info.csv
 config_old
-
-venv/*

--- a/tinker/events/forms.py
+++ b/tinker/events/forms.py
@@ -115,11 +115,11 @@ class HeadingField(Field):
     def __html__(self):
         return None
 
-#Long words throw off formatting in Calendar
+# Long words throw off formatting in Calendar
 def length_checker(Form, field):
     word_split = field.data.split(" ")
-    for words in word_split:
-        if len(words) > 15:
+    for word in word_split:
+        if len(word) > 15:
             raise ValidationError('Words in the title must be 15 characters or less')
 
 
@@ -196,6 +196,3 @@ class EventForm(Form):
                                            validators=[DataRequired()])
     internal = SelectMultipleField('Internal only', default=['None'], choices=internal_choices,
                                    validators=[DataRequired()])
-
-
-

--- a/tinker/events/forms.py
+++ b/tinker/events/forms.py
@@ -120,7 +120,7 @@ def length_checker(Form, field):
     word_split = field.data.split(" ")
     for words in word_split:
         if len(words) > 15:
-            raise ValidationError('Words in the Title must be less than 15 Characters')
+            raise ValidationError('Words in the title must be 15 characters or less')
 
 
 class EventForm(Form):

--- a/tinker/events/forms.py
+++ b/tinker/events/forms.py
@@ -7,7 +7,7 @@ from bu_cascade.asset_tools import find, convert_asset
 from flask import session
 from flask_wtf import Form
 from wtforms import DateTimeField, Field, HiddenField, SelectField, SelectMultipleField, StringField, TextAreaField
-from wtforms.validators import DataRequired , ValidationError
+from wtforms.validators import DataRequired, ValidationError
 
 # Local
 from tinker.tinker_controller import TinkerController
@@ -116,11 +116,11 @@ class HeadingField(Field):
         return None
 
 
-def length_check(self, form, field):
+def length_checker(Form, field):
     word_split = field.data.split(" ")
     for words in word_split:
         if len(words) > 15:
-            raise ValidationError('Words in the Title must be less that 15 Characters')
+            raise ValidationError('Words in the Title must be less than 15 Characters')
 
 
 class EventForm(Form):
@@ -140,7 +140,7 @@ class EventForm(Form):
     heading_choices = (('', '-select-'), ('Registration', 'Registration'), ('Ticketing', 'Ticketing'))
 
     what = HeadingField(label="What is your event?")
-    title = StringField('Event name', validators=[DataRequired()], format=length_check, description="This will be the title of your webpage")
+    title = StringField('Event name', validators=[DataRequired() , length_checker], description="This will be the title of your webpage")
 
     metaDescription = StringField('Teaser',
                                   description=u'Short (1 sentence) description. What will the attendees expect? This will appear in event viewers and on the calendar.',
@@ -196,5 +196,6 @@ class EventForm(Form):
                                            validators=[DataRequired()])
     internal = SelectMultipleField('Internal only', default=['None'], choices=internal_choices,
                                    validators=[DataRequired()])
+
 
 

--- a/tinker/events/forms.py
+++ b/tinker/events/forms.py
@@ -115,7 +115,7 @@ class HeadingField(Field):
     def __html__(self):
         return None
 
-
+#Long words throw off formatting in Calendar
 def length_checker(Form, field):
     word_split = field.data.split(" ")
     for words in word_split:

--- a/tinker/events/forms.py
+++ b/tinker/events/forms.py
@@ -7,7 +7,7 @@ from bu_cascade.asset_tools import find, convert_asset
 from flask import session
 from flask_wtf import Form
 from wtforms import DateTimeField, Field, HiddenField, SelectField, SelectMultipleField, StringField, TextAreaField
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired , ValidationError
 
 # Local
 from tinker.tinker_controller import TinkerController
@@ -116,6 +116,13 @@ class HeadingField(Field):
         return None
 
 
+def length_check(self, form, field):
+    word_split = field.data.split(" ")
+    for words in word_split:
+        if len(words) > 15:
+            raise ValidationError('Words in the Title must be less that 15 Characters')
+
+
 class EventForm(Form):
     image = HiddenField("Image path")
 
@@ -133,7 +140,8 @@ class EventForm(Form):
     heading_choices = (('', '-select-'), ('Registration', 'Registration'), ('Ticketing', 'Ticketing'))
 
     what = HeadingField(label="What is your event?")
-    title = StringField('Event name', validators=[DataRequired()], description="This will be the title of your webpage")
+    title = StringField('Event name', validators=[DataRequired()], format=length_check, description="This will be the title of your webpage")
+
     metaDescription = StringField('Teaser',
                                   description=u'Short (1 sentence) description. What will the attendees expect? This will appear in event viewers and on the calendar.',
                                   validators=[DataRequired()])
@@ -188,3 +196,5 @@ class EventForm(Form):
                                            validators=[DataRequired()])
     internal = SelectMultipleField('Internal only', default=['None'], choices=internal_choices,
                                    validators=[DataRequired()])
+
+


### PR DESCRIPTION
## Description

If a word is too long in the event title, it will throw off the formatting. Josiah and I thought 15 characters would be a good length to limit words to. That could easily be changed if it needs to be longer or shorter. I threw a Validation Error if a word is too long

Fixes # (issue)

Long words in a title throw off Calendar formatting

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this


- Bug fix

## How Has This Been Tested?

I tested by having a title with many short words. That passed. I tested with a word that is 15 characters. That passed. I tested with a word that is 16 characters. That failed. I tested with many long and many short words. That failed. I haven't tested on another server but I could. I did test in many browsers and it worked.

Please briefly describe the tests that you ran to verify your changes.

I had event titles of different length and if a word was over 15 characters, an error appeared telling the user "Words in the title must be 15 characters or less"

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)