### PR TITLE
New events, bios, announcements now show log ID when created

### DIFF
--- a/tinker/e_announcements/__init__.py
+++ b/tinker/e_announcements/__init__.py
@@ -187,7 +187,7 @@ class EAnnouncementsView(FlaskView):
             asset = self.base.update_structure(e_announcement_data, rform, e_announcement_id=eaid)
             resp = self.base.create_block(asset)
             new_eaid = resp.asset['xhtmlDataDefinitionBlock']['id']
-            self.base.log_sentry('New e-announcement submission', resp)
+            self.base.log_sentry('New e-announcement submission', "createdAssetId = " + new_eaid)
         else:
             block = self.base.read_block(eaid)
             e_announcement_data, mdata, sdata = block.read_asset()

--- a/tinker/events/events_controller.py
+++ b/tinker/events/events_controller.py
@@ -133,7 +133,7 @@ class EventsController(TinkerController):
                                           workflow=workflow)
             resp = self.create_page(asset)
             eid = resp.asset['page']['id']
-            self.log_sentry("New event submission", resp)
+            self.log_sentry("New event submission", "createdAssetId = " + eid)
         else:
             page = self.read_page(eid)
             event_data, metadata, structured_data = page.get_asset()

--- a/tinker/faculty_bios/__init__.py
+++ b/tinker/faculty_bios/__init__.py
@@ -245,7 +245,7 @@ class FacultyBiosView(FlaskView):
             resp = self.base.create_page(asset)
             faculty_bio_id = resp.asset['page']['id']
             self.base.cascade_call_logger(locals())
-            self.base.log_sentry("Faculty bio new submission", resp)
+            self.base.log_sentry("Faculty bio new submission", "createdAssetId = " + faculty_bio_id)
             status = 'new'
 
         self.base.publish(app.config['FACULTY_BIOS_XML_ID'])


### PR DESCRIPTION
## Description

When new events, faculty bios, and e-announcements are created, they now show their ID in the error logs rather than showing an object with no useful information.

Instead of: 
_Thu Feb  4 11:31:30 2021: Faculty bio new submission: trv48226 <bu_cascade.assets.page.Page object at 0x1131c3f98>_
It now shows:
_Tue Feb  9 11:06:58 2021: Faculty bio new submission: trv48226 createdAssetId = 87c2a5b28c5865fc7739d2f090601293_

Fixes # ITS-177426

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

I submitted some test bios/events/announcements with changes and they showed the created submission with the new ID

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)