### PR TITLE
Bm strptime fix

### DIFF
--- a/tinker/events/events_controller.py
+++ b/tinker/events/events_controller.py
@@ -194,8 +194,8 @@ class EventsController(TinkerController):
             # Get rid of the fancy formatting so we just have normal numbers
             start = event_dates[i]['start_date'].split(' ')
             end = event_dates[i]['end_date'].split(' ')
-            start[1] = start[1].replace('th', '').replace('st', '').replace('rd', '').replace('nd', '')
-            end[1] = end[1].replace('th', '').replace('st', '').replace('rd', '').replace('nd', '')
+            start[1] = start[1].replace('th', '').replace('st', '').replace('rd', '').replace('nd', '').replace('.' '')
+            end[1] = end[1].replace('th', '').replace('st', '').replace('rd', '').replace('nd', '').replace('.', '')
 
             start = " ".join(start)
             end = " ".join(end)

--- a/tinker/events/events_controller.py
+++ b/tinker/events/events_controller.py
@@ -389,10 +389,10 @@ class EventsController(TinkerController):
         max_year = 0
         for date in dates:
             date_str = self.timestamp_to_date_str(date['end-date'])
-            end_date = datetime.datetime.strptime(date_str, '%B %d %Y, %I:%M %p').date()
             try:
+                end_date = datetime.datetime.strptime(date_str, '%B %d %Y, %I:%M %p').date()
                 year = end_date.year
-            except AttributeError:
+            except Exception:
                 # if end_date is none and this fails, revert to current year.
                 year = datetime.date.today().year
             if year > max_year:


### PR DESCRIPTION
## Description

Sentry threw an error that strptime was being fed None instead of a datetime string, it seems that the only way it was fed None was if changing the date to a timestamp failed. We have a try catch for this already (with a comment on what it is used for) except that part that it was trying to stop from failing wasn't inside the try catch so I just moved it in. I also added it another way to format the date which is to look and replace periods with nothing since periods should not be in am/pm (ex a.m., p.m.).

Fixes sentry issue

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Tested locally but I couldn't replicate any of the tests failing without manually entering in a date so manually set the date so it would fail and fixed the issues.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)