### PR TITLE
Fixes accented letters in cascade

### DIFF
--- a/tinker/faculty_bios/faculty_bio_controller.py
+++ b/tinker/faculty_bios/faculty_bio_controller.py
@@ -431,6 +431,7 @@ class FacultyBioController(TinkerController):
         # todo: this is a temp fix to override the already set system-name
         new_system_name = add_data['last'].strip() + '-' + add_data['first'].strip()
         new_system_name = new_system_name.lower().replace(' ', '-')
+        new_system_name = unidecode(new_system_name)
         add_data['system_name'] = re.sub(r'[^a-zA-Z0-9-]', '', new_system_name)
 
         # this needs to be done AFTER the system name is made.

--- a/tinker/tinker_controller.py
+++ b/tinker/tinker_controller.py
@@ -445,6 +445,7 @@ class TinkerController(object):
             add_data['title'] = title
             # Create the system-name from title, all lowercase, remove any non a-z, A-Z, 0-9
             system_name = title.lower().replace(' ', '-')
+            system_name = unidecode(system_name)
             add_data['system_name'] = re.sub(r'[^a-zA-Z0-9-]', '', system_name)
             add_data['name'] = add_data['system_name']
 


### PR DESCRIPTION
## Description

Names in cascade before got rid of accented letters in the title. Now the accented letters are converted to normal letters so they appear in the titles.

Fixes #380 

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

I sent some faculty bios to https://cms.bethel.edu/entity/open.act?id=ba13b2338c586513100ee2a71bd61506&type=folder with accented letters. With the name, "éáíóú Test", the title in cascade was "-test". After my changes, it is now "eaiou-test". 

Another test with more accented letters and weird letters looked to appear properly:

<img width="681" alt="Screen Shot 2021-06-29 at 2 30 59 PM" src="https://user-images.githubusercontent.com/58450961/123856425-b3781080-d8e6-11eb-89b0-787d130368ce.png">

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)