### PR TITLE
add in html unescape tool

### DIFF
--- a/tinker/faculty_bios/faculty_bio_controller.py
+++ b/tinker/faculty_bios/faculty_bio_controller.py
@@ -4,6 +4,7 @@ import json
 import re
 import os
 import platform
+import html
 
 # Packages
 from bu_cascade.asset_tools import find
@@ -747,7 +748,7 @@ class FacultyBioController(TinkerController):
         return ''.join(options)
 
     def replace_html_entity(self, data, key):
-        data[key] = data[key].replace('&nbsp;', ' ')
+        data[key] = html.unescape(data[key])
 
     # this callback is used with the /edit_all endpoint. The primary use is to modify all assets
     def edit_all_callback(self, asset_data):


### PR DESCRIPTION
## Description

Hopefully crush all issues surrounding faculty bios and copying and pasting from word by using html to unescape the text.

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

I tested it locally but would like to test it more before I merge.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)