### PR TITLE
Makes news email image a clickable link

### DIFF
--- a/tinker/templates/news/article.html
+++ b/tinker/templates/news/article.html
@@ -8,7 +8,7 @@
                 </div>
                 <div style="Margin-left: 20px;Margin-right: 20px;">
                     {# 1000 pixels will cover the largest size that will appear in an email, since we restrict the width of the email content. #}
-                    <img src="https://cdn1.bethel.edu/resize/unsafe/1000x0/smart/https://https://www.bethel.edu/{{ image_path }}" width="100%">
+                    <a href="https://www.bethel.edu/{{ path }}"><img src="https://cdn1.bethel.edu/resize/unsafe/1000x0/smart/https://https://www.bethel.edu/{{ image_path }}" width="100%"></a>
                     {{ content|safe }}
                     <div style="text-align:center;padding-top:30px"><!--[if mso]>
                       <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://www.bethel.edu/{{ path }}" style="height:40px;v-text-anchor:middle;width:200px;" arcsize="8%" strokecolor="#1e3650" fillcolor="#0069aa">


### PR DESCRIPTION
## Description

Makes the image in the Bethel News emails a clickable link

Fixes #NA

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

With the inspect tool in Firefox and safari

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)