### PR TITLE
Fixes ampersand issue

### DIFF
--- a/tinker/faculty_bios/faculty_bio_controller.py
+++ b/tinker/faculty_bios/faculty_bio_controller.py
@@ -438,6 +438,11 @@ class FacultyBioController(TinkerController):
         # this needs to be done AFTER the system name is made.
         add_data['image'] = self.create_faculty_bio_image(add_data)
 
+        # Cascade doesn't play well with ampersands so they need to be formatted differently
+        for key, value in add_data.items():
+            if key in ('biography', 'courses', 'awards', 'publications', 'presentations', 'certificates', 'organizations', 'hobbies') and value.__contains__('&'):
+                add_data[key] = add_data[key].replace('&', '&amp;amp;')
+
         workflow_id = self.get_correct_workflow_id(add_data, submitter_groups)
         workflow = self.create_workflow(workflow_id, subtitle=add_data['title'])
         self.add_workflow_to_asset(workflow, faculty_bio_data)
@@ -723,8 +728,8 @@ class FacultyBioController(TinkerController):
         if add_data.get('certificates', None):
             self.replace_html_entity(add_data, 'certificates')
             options.append("::CONTENT-XML-CHECKBOX::Certificates and Licenses")
-        if add_data.get('courses', None):
-            self.replace_html_entity(add_data, 'courses')
+        if add_data.get('organizations', None):
+            self.replace_html_entity(add_data, 'organizations')
             options.append("::CONTENT-XML-CHECKBOX::Professional Organizations, Committees, and Boards")
         if add_data.get('hobbies', None):
             self.replace_html_entity(add_data, 'hobbies')


### PR DESCRIPTION
- Fixes issue where ampersands throw an error in cascade
- Also fixes what looks to be a mistake in copy and pasting from the past. Organization info is now updated correctly

## Description

There was an issue in the faculty bios in Cascade where an ampersand would throw an error in Cascade when sent over from tinker in one of 8 html text categories for faculty bios. Code in Cascade used to display information would throw an error whenever .textvalue was called on a piece of text with an ampersand because the ampersand was unescaped and couldn't be escaped. I also found an error that was not running correct code on the organization category in faculty bios. I am guessing this was due to someone copying and pasting in the past and was preventing text in the organization category from being formatted correctly when being sent over.
In order to fix previous ampersand errors, the faculty information must be resent from Tinker even if no information is changed.

Fixes #NA

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

I looked at both Tinker and Cascade code and couldn't fix it in Cascade but I found a fix in Tinker. I typed information with ampersands including urls and sent them over as workflows to Tinker (and deleted them after). The pages before (or when sent from the previous versions of Tinker) caused errors but my fix displayed an error free page. I tried many faculty bios that were broken or normal before and they displayed correctly.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)