### PR TITLE
new routes for testing news

### DIFF
--- a/tinker/news/__init__.py
+++ b/tinker/news/__init__.py
@@ -1,11 +1,15 @@
 # Global
 import datetime
 import html
+import traceback
+import sys
+import random
 
 # Packages
 from bu_cascade.asset_tools import find
 from createsend import Campaign, CreateSend
-from flask_classy import FlaskView, route
+from flask_classy import FlaskView, request, route
+from flask import abort, render_template, session, redirect, url_for
 
 # Local
 from tinker.news.campaign_controller import NewsController
@@ -22,20 +26,45 @@ class NewsView(FlaskView):
     def before_request(self, name, **kwargs):
         pass
 
+
+    @route('/api/test', methods=['get', 'post'])
+    @requires_auth
+    def test(self):
+       print(request.url_rule.rule)
+       return "see console print"
+
+    # Added "create-and-send-email" and "create-email" (mimics the E-annz routes for better debugging)
     @requires_auth
     @route('/api/send-email/<article_id>', methods=['get', 'post'])
+    @route('/api/create-email/<article_id>', methods=['get', 'post'])
+    @route('/api/create-and-send-email/<article_id>', methods=['get', 'post'])
+    @route('/api/create-email-with-preview/<article_id>', methods=['get', 'post'])
     def reset_send_email(self, article_id):
         try:
             resp = 'failed'
+
+            actually_send_email = False
+            if 'send-email' in request.url_rule.rule:
+                actually_send_email = True
+
+            just_send_preview = False
+            if 'with-preview' in request.url_rule.rule:
+                just_send_preview = True
+
             page = self.base_campaign.read_page(article_id)
             article_asset, md, sd = page.get_asset()
 
             news_article_datetime = datetime.datetime.fromtimestamp(int(find(sd, 'publish-date', False))/1000)
-            current_datetime = datetime.datetime.now()
+            current_datetime = datetime.datetime.fromtimestamp(int(find(sd, 'publish-date', False))/1000)
 
             # ignore any that are on a different day, or in _testing
-            if news_article_datetime.strftime("%m-%d-%Y") != current_datetime.strftime("%m-%d-%Y") or '_testing/' in find(article_asset, 'path', False):
-                return "Don't need to send"
+            is_different_day = news_article_datetime.strftime("%m-%d-%Y") != current_datetime.strftime("%m-%d-%Y")
+            if is_different_day and actually_send_email:
+                return "Cannot send, wrong day"
+
+            is_testing_page = '_testing/' in find(article_asset, 'path', False)
+            if is_testing_page and actually_send_email:
+                return "Don't need to send, the page is in testing."
 
             # add news_article
             news_article_text = self.base_campaign.create_single_news_article(article_asset, news_article_datetime)
@@ -63,23 +92,50 @@ class NewsView(FlaskView):
                     ]
                 }
 
-                send_email_value = find(sd, 'send-email', False)
+                needs_sending = find(sd, 'send-email', False)
 
-                if app.config['ENVIRON'] == 'prod' and send_email_value == 'Yes':
-                    self.base_campaign.reset_send_email_value(page)
-
+                if app.config['ENVIRON'] == 'prod':
+                    # Create the campaign and get necessary info for send
                     resp = new_campaign.create_from_template(client_id, subject, name, from_name, from_email, reply_to,
-                                                             list_ids,
-                                                             segment_ids, template_id, template_content)
-
+                                                             list_ids, segment_ids, template_id, template_content)
                     now = self.base_campaign.date_without_dst()
                     now_plus_10 = now + datetime.timedelta(minutes=10)
-
                     confirmation_email_sent_to = ', '.join(app.config['ADMINS'])
-                    new_campaign.send(confirmation_email_sent_to, str(now_plus_10.strftime('%Y-%m-%d %H:%M')))
-                    self.base_campaign.log_sentry("News campaign created", resp)
+
+                    # if this is a real campaign, send the emails
+                    if actually_send_email and needs_sending == "Yes":
+                        # Mark this page as having been sent already (bu_cascade)
+                        page.update_and_edit('sd', 'send-email', 'No')
+                        self.base_campaign.publish(article_id)
+
+                        # Send the emails (createsend)
+                        new_campaign.send(confirmation_email_sent_to, str(now_plus_10.strftime('%Y-%m-%d %H:%M')))
+                        self.base_campaign.log_sentry("News campaign created", resp)
+
+                    # if this is is not a real campaign, send emails only if a preview is requested
+                    else:
+                        if just_send_preview:
+                            # Mark this page as having been sent already (leave commented when not testing)
+                            # page.update_and_edit('sd', 'send-email', 'No')
+                            # self.base_campaign.publish(article_id)
+
+                            new_campaign.send_preview(confirmation_email_sent_to)
+                            self.base_campaign.log_sentry("News campaign created and sent as preview", resp)
+                        else:
+                            self.base_campaign.log_sentry("News campaign created but not sent", resp)
+
+            return str(resp)
 
         except:
-            return 'failed'
+            exc_type, exc_value, exc_traceback = sys.exc_info()
 
-        return resp
+            if str(exc_value) == "The CreateSend API responded with the following error - 303: Duplicate Campaign Name":
+                self.base_campaign.log_sentry("News had an error. It looks like it tried to send a duplicate campaign, and was stopped, with error", resp)
+                return "(CreateSend 303 Error) Duplicate Campaign Name."
+
+            # Only print traceback when testing
+            if False:
+                print(traceback.format_exc())
+
+            self.base_campaign.log_sentry("News had an error. It seems to have exited without sending the campaign, with error", resp)
+            return str(resp)

--- a/tinker/news/campaign_controller.py
+++ b/tinker/news/campaign_controller.py
@@ -88,11 +88,6 @@ class NewsController(TinkerController):
             if anchor_tag['href'][0] == '/':
                 anchor_tag['href'] = 'https://www.bethel.edu' + anchor_tag['href']
 
-    def reset_send_email_value(self, page):
-        asset, md, sd = page.get_asset()
-        update(sd, 'send-email', 'No')
-        page.edit_asset(asset)
-
     def date_without_dst(self):
         now = datetime.datetime.now()
         tz = pytz.timezone('US/Central').localize(now).strftime('%z')


### PR DESCRIPTION
## Description

Response to [[ITS-223308]](https://jira.bethel.edu/browse/ITS-223308). 

News campaigns were not sending properly, apparently due to some issues with the API calls to bu_cascade. After [making changes to the API]( https://github.com/betheluniversity/cascade/pull/771) and using a new method which simplifies the update/edit process, news articles are now correctly marked as sent when they need to be.
This update also adds a few more routes to the send-email message which can send the email in preview mode or just create it, rather than officially sending it, which is done with the email-sending E Announcements code as well.

## Size and Type of change
- Small Change - 1 person needs to review this
- Bug fix
- Venv update needed (?)

## How Has This Been Tested?
I sent the emails locally from prod via the testing routes I added, using an article in my _testing folder on Cascade. Preview emails were sending properly, and I can see that Tinker is editing the send-email value on the Cascade page.

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)