### PR TITLE
The Great 503 Page Update

### DIFF
--- a/tinker/__init__.py
+++ b/tinker/__init__.py
@@ -5,7 +5,7 @@ import platform
 
 # Packages
 from bu_cascade.cascade_connector import Cascade
-from flask import Flask, make_response, redirect, session, url_for
+from flask import Flask, make_response, redirect, session, url_for, abort
 from flask_caching import Cache
 from flask_sqlalchemy import SQLAlchemy
 import sentry_sdk
@@ -138,6 +138,8 @@ View.register(app)
 
 @app.before_request
 def before_request():
+    if app.config['SERVER_DOWN']:
+        abort(503)
     base = TinkerController()
     base.before_request()
 


### PR DESCRIPTION
## Description

## Description

Part of [The Great 503 Page Update](https://jira.bethel.edu/browse/ITS-208868). Adds a way to "turn on" the 503 page in the config if we know the site is down. 

NOTE: This one does not include an ERROR_MESSAGE variable in the config as well, due to the error message on the existing 503 page.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature
- Config update needed

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

Locally, I can tell that toggling the "SERVER_DOWN" config value between True and False works as expected.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)