### PR TITLE
no cascade links unless Administrators

### DIFF
--- a/tinker/templates/e-announcements/results.html
+++ b/tinker/templates/e-announcements/results.html
@@ -3,8 +3,12 @@
     <div class="card">
         <div class="content">
             <p>
-                {% if form.path != '' %}
-                    <a href="https://cms.bethel.edu/entity/open.act?id={{ form.id }}&type=block">{{ form.title }}</a>
+                {% if 'Administrators' in session['groups'] %}
+                    {% if form.path != '' %}
+                        <a href="https://cms.bethel.edu/entity/open.act?id={{ form.id }}&type=block">{{ form.title }}</a>
+                    {% else %}
+                        {{ form.title }}
+                    {% endif %}
                 {% else %}
                     {{ form.title }}
                 {% endif %}


### PR DESCRIPTION
## Description

Users submitting E-Announcements were presented with links to the block in Cascade which they are not able to access. This was causing confusion.

Fixes # https://betheluniversity.atlassian.net/browse/ITS-263804

## Size and Type of change
- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

Locally, XP, and Prod.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)